### PR TITLE
Filepath cleanup

### DIFF
--- a/cmd/count.go
+++ b/cmd/count.go
@@ -19,7 +19,9 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -41,8 +43,12 @@ func init() {
 }
 
 func lineCounter() {
-	homedir := os.Getenv(("HOME"))
-	upFile := homedir + "/.tidy/up"
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal("Could not determine user home directory")
+	}
+
+	upFile := filepath.Join(homeDir, ".tidy", "up")
 	counter := 0
 	f, err := os.Open(upFile)
 	check(err)

--- a/cmd/del.go
+++ b/cmd/del.go
@@ -17,7 +17,9 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"log"
 	"os"
+	"path/filepath"
 )
 
 // delCmd represents the del command
@@ -37,8 +39,12 @@ var delCmd = &cobra.Command{
 	Removed di from up.
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		homedir := os.Getenv(("HOME"))
-		upFile := homedir + "/.tidy/up"
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal("Could not determine user home directory")
+		}
+
+		upFile := filepath.Join(homeDir, ".tidy", "up")
 		size, err := GetFileSize(upFile)
 		check(err)
 		if size == 0 {

--- a/cmd/e.go
+++ b/cmd/e.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -35,8 +36,13 @@ var eCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Function to edit configs
-		homedir := os.Getenv(("HOME"))
-		upFile := homedir + "/.tidy/up"
+
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal("Could not determine user home directory")
+		}
+
+		upFile := filepath.Join(homeDir, ".tidy", "up")
 		edit := getRow(upFile)
 		keyOrValue(edit, upFile)
 	},
@@ -184,8 +190,13 @@ func writeReplace(changeReq string, userEdit string, oldAlias string, oldCmd str
 			}
 		}
 	}
-	homedir := os.Getenv(("HOME"))
-	upFile := homedir + "/.tidy/up"
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal("Could not determine user home directory")
+	}
+
+	upFile := filepath.Join(homeDir, ".tidy", "up")
 	if changeReq == "Alias" {
 		oldconv := []string{oldCmd}
 		upList := chore{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,7 +17,9 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -30,20 +32,26 @@ var initCmd = &cobra.Command{
 	Long: `Adds a directory called .tidy and a file to store aliases in called "up".
 	It looks explicitly for the $HOME directory.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		tidypath := ".tidy"
-		homedir := os.Getenv(("HOME"))
-		up := "up"
-		if _, err := os.Stat(homedir + "/" + tidypath); os.IsNotExist(err) {
+
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal("Could not determine user home directory")
+		}
+
+		tidyPath := filepath.Join(homeDir, ".tidy")
+		upPath := filepath.Join(tidyPath, "up")
+
+		if _, err := os.Stat(tidyPath); os.IsNotExist(err) {
 			// .tidy does not already exist.
 			fmt.Println("Creating your .tidy/up...")
-			os.MkdirAll(homedir+"/"+tidypath, 0777)
-			os.Create(homedir + "/" + tidypath + "/" + up)
+			os.MkdirAll(tidyPath, 0777)
+			os.Create(upPath)
 			fmt.Println(".tidy/up configured.")
 
 		} else {
-			if _, err := os.Stat(homedir + "/" + tidypath + "/" + up); os.IsNotExist(err) {
+			if _, err := os.Stat(upPath); os.IsNotExist(err) {
 				fmt.Println("Missing up... creating for you now...")
-				os.Create(homedir + "/" + tidypath + "/" + up)
+				os.Create(upPath)
 				fmt.Println(".tidy/up configured.")
 			} else {
 				fmt.Println(".tidy/up already configured.")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -39,8 +40,11 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		homedir := os.Getenv(("HOME"))
-		upFile := homedir + "/.tidy/up"
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal("Could not determine user home directory")
+		}
+		upFile := filepath.Join(homeDir, ".tidy", "up")
 		size, err := GetFileSize(upFile)
 		check(err)
 		// If the up file contains data


### PR DESCRIPTION
Replaced potentially platform-specific os.GetEnv("HOME") with platform-agnostic os.UserHomeDirectory()
Replaced *nix-specific path concatenation with platform-agnostic filepath.Join()
Cleaned up initCmd to use more compact, readable variable names instead of in-place concatenations.